### PR TITLE
Fix netctldlist produces empty output

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,14 +6,14 @@ pkgver=2
 pkgrel=2
 pkgdesc='A wifi controller for dmenu'
 arch=('x86_64')
-url="https://github.com/UnlimitedWand/${_pkgname}"
+url="https://github.com/tmathmeyer/${_pkgname}"
 license=('GPL')
 depends=(dmenu)
 makedepends=('git')
 optdepends=(systemd)
 provides=("${_pkgname}")
 conflicts=("${_pkgname}")
-source=("git://github.com/UnlimitedWand/${_pkgname}.git")
+source=("git://github.com/tmathmeyer/${_pkgname}.git")
 md5sums=('SKIP')
 
 pkgver() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,17 +3,17 @@
 _pkgname=netmenu
 pkgname=${_pkgname}
 pkgver=2
-pkgrel=1
+pkgrel=2
 pkgdesc='A wifi controller for dmenu'
 arch=('x86_64')
-url="https://github.com/tmathmeyer/${_pkgname}"
+url="https://github.com/UnlimitedWand/${_pkgname}"
 license=('GPL')
 depends=(dmenu)
 makedepends=('git')
 optdepends=(systemd)
 provides=("${_pkgname}")
 conflicts=("${_pkgname}")
-source=("git://github.com/tmathmeyer/${_pkgname}.git")
+source=("git://github.com/UnlimitedWand/${_pkgname}.git")
 md5sums=('SKIP')
 
 pkgver() {

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# netmenu
+a netctl controller / deamon 
+
+### 1. Use systemctl to start netctld
+The commond is ```sudo systemctl start netmenu```, considering the old installation you may need stop it at first(using ```sudo systemctl stop netmenu```).
+If you want it runs when you computer starts up, run ```sudo systemctl enable netmenu```.
+
+### 2. Run netmenu
+You can run dmenu first or run netmenu directly, then dmenu bar will show your network configures under ```/etc/netctl``` directory. 
+Use left/right arrow choose a network, press enter to connect.
+
+### 3. Add new network configure
+Choose ```+ new interface```, netmenu will open a terminal to start wifi-menu (need install), the default terminal is urxvt. To use you own terminal, simply put a
+symlink into some directory in your path by running ```ln -s <source> <target>```

--- a/netctld.c
+++ b/netctld.c
@@ -213,7 +213,7 @@ int write_sysctl(char *buffer, char *profile) {
 int write_chars_to_buffer(char *buffer, const char *data) {
     int count = 0; 
     while(data[count]) {
-        buffer[count] = data[count++];
+        buffer[count-1] = data[count++];
     }
     return count;
 }

--- a/netctldlist.c
+++ b/netctldlist.c
@@ -24,6 +24,7 @@ int main(void)
     remote.sun_family = AF_UNIX;
     strcpy(remote.sun_path, SOCK_PATH);
     len = strlen(remote.sun_path) + sizeof(remote.sun_family);
+    bind(s, (struct sockaddr *)&remote, len);
     if (connect(s, (struct sockaddr *)&remote, len) == -1) {
         exit(2);
     }

--- a/netctldlist.c
+++ b/netctldlist.c
@@ -25,11 +25,11 @@ int main(void)
     strcpy(remote.sun_path, SOCK_PATH);
     len = strlen(remote.sun_path) + sizeof(remote.sun_family);
     if (connect(s, (struct sockaddr *)&remote, len) == -1) {
-        exit(1);
+        exit(2);
     }
 
     if (send(s, "list", 5, 0) == -1) {
-        exit(1);
+        exit(3);
     }
 
     size_t size = 0;

--- a/netctldlist.c
+++ b/netctldlist.c
@@ -24,13 +24,12 @@ int main(void)
     remote.sun_family = AF_UNIX;
     strcpy(remote.sun_path, SOCK_PATH);
     len = strlen(remote.sun_path) + sizeof(remote.sun_family);
-    bind(s, (struct sockaddr *)&remote, len);
     if (connect(s, (struct sockaddr *)&remote, len) == -1) {
-        exit(2);
+        exit(1);
     }
 
     if (send(s, "list", 5, 0) == -1) {
-        exit(3);
+        exit(1);
     }
 
     size_t size = 0;
@@ -41,7 +40,7 @@ int main(void)
             printf(str);
         }
         free(str);
-        printf("\n+ new interface");
+        printf("+ new interface");
     }
 
 

--- a/netmenu
+++ b/netmenu
@@ -2,7 +2,7 @@
 
 netctldlist > .wifi-info 2>/dev/null
 
-CONNECT=$(exec dmenu $@ < .wifi-info)
+CONNECT=$(exec dmenu "$@" < .wifi-info)
 
 if [ -n "$CONNECT" ]; then
     echo $CONNECT | netctldcli


### PR DESCRIPTION
Hi tmathmeyer, 
I try to fix the bug, it seems the buffer[0] in function **`write_chars_to_buffer`** is always **0** , and it causes the problem, and $@ without double quotation marks may cause parameter passing error. If you receive this pull request, please consider merging it.